### PR TITLE
Added support for the content type application/json; charset=utf-8

### DIFF
--- a/check_json.pl
+++ b/check_json.pl
@@ -59,6 +59,7 @@ eval {
   exit EXIT_CRITICAL;
 };
 
+$status = EXIT_OK;
 
 if ($opts{d}) {
 

--- a/check_json.pl
+++ b/check_json.pl
@@ -7,7 +7,7 @@ use LWP::UserAgent;
 use JSON 'decode_json';
 
 my $plugin_name = "Nagios check_http_json";
-my $VERSION = "1.00";
+my $VERSION = "1.01";
 
 # getopt module config
 $Getopt::Std::STANDARD_HELP_VERSION = 1;
@@ -40,7 +40,7 @@ $ua->timeout($opts{t});
 
 my $response = $ua->get($opts{U});
 
-if ( $response->header("content-type") ne 'application/json' )
+if ( index($response->header("content-type"), 'application/json') == -1 )
 {
   print "Expected content-type to be application/json, got ", $response->header("content-type");
   exit EXIT_CRITICAL;


### PR DESCRIPTION
One liner to add check if the content-type contains application/json instead of equals the string.  That way if the charset is included it still tries to decode the JSON data.  

Also, if you only do the -U option, it would exit with status UNKNOWN, updated it to exit with status OK.

Bumped the version from 1.00 to 1.01.

Thanks for sharing this, it was super useful and saved me a ton of time!
-James
